### PR TITLE
fix ()s in functionExpr, functionDecl

### DIFF
--- a/src/tinyses.js
+++ b/src/tinyses.js
@@ -222,9 +222,9 @@ module.exports = (function() {
     # The expr form must come after the block form, to make proper use
     # of PEG prioritized choice.
     arrow ::=
-      params NO_NEWLINE "=>" block                         ${(ps,_,_2,b) => ['arrow',ps,b]}
-    / params NO_NEWLINE "=>" expr                          ${(ps,_,_2,e) => ['lambda',ps,e]};
-    params ::=
+      arrowParams NO_NEWLINE "=>" block                         ${(ps,_,_2,b) => ['arrow',ps,b]}
+    / arrowParams NO_NEWLINE "=>" expr                          ${(ps,_,_2,e) => ['lambda',ps,e]};
+    arrowParams ::=
       IDENT                                                ${id => [['def',id]]}
     / "(" param ** "," ")"                                 ${(_,ps,_2) => ps};
 

--- a/src/tinyses.js
+++ b/src/tinyses.js
@@ -282,11 +282,11 @@ module.exports = (function() {
 
 
     functionExpr ::=
-      "function" defVar? "(" params ")" block          ${(_,n,_2,p,_3,b) => ['functionExpr',n,p,b]};
+      "function" defVar? "(" param ** "," ")" block          ${(_,n,_2,p,_3,b) => ['functionExpr',n,p,b]};
     functionDecl ::=
-      "function" defVar "(" params ")" block           ${(_,n,_2,p,_3,b) => ['functionDecl',n,p,b]};
+      "function" defVar "(" param ** "," ")" block           ${(_,n,_2,p,_3,b) => ['functionDecl',n,p,b]};
     methodDef
-      propName "(" params ")" block                    ${(n,_,p,_2,b) => ['methodDef',n,p,b]}
+      propName "(" param ** "," ")" block                    ${(n,_,p,_2,b) => ['methodDef',n,p,b]}
     / identGet propName "(" ")" block                  ${(_,n,_2,_3,b) => ['getter',n,[],b]}
     / identSet propName "(" param ")" block            ${(_,n,_2,p,_3,b) => ['setter',n,[p],b]};
 


### PR DESCRIPTION
use `param ** ","` rather than `params`, which already has `( ... )`

fixes #6